### PR TITLE
Reverse 1:n relationships

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -107,7 +107,7 @@ type Transaction @entity {
     id: ID!  # txn  hash concatenated with exchange - need this for token to token swaps
     exchangeAddress: Bytes!
     addLiquidityEvents: [AddLiquidityEvent!] @derivedFrom(field: "transaction")
-    removeLiquidityEvents: [RemoveLiquidityEvent!]
+    removeLiquidityEvents: [RemoveLiquidityEvent!] @derivedFrom(field: "transaction")
     tokenPurchaseEvents: [TokenPurchaseEvent!]
     ethPurchaseEvents: [EthPurchaseEvent!]
     block: Int!
@@ -135,7 +135,7 @@ type AddLiquidityEvent implements TransactionEvent  @entity {
 # Note - No fee to provide liqidity
 type RemoveLiquidityEvent implements TransactionEvent @entity {
     id: ID!                 # Incrementing ID, 1, 2, etc, as txhashes can contain multiple events
-    transaction: Transaction! @derivedFrom(field: "removeLiquidityEvents")
+    transaction: Transaction!
     ethAmount: BigDecimal!
     tokenAmount: BigDecimal!
     uniTokensBurned: BigDecimal!

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,7 +2,7 @@
 type Uniswap @entity {
     id: ID!
     exchangeCount: Int!
-    exchanges: [Exchange!]!
+    exchanges: [Exchange!]!  @derivedFrom(field: "factory")
     totalVolumeInEth: BigDecimal!
     totalLiquidityInEth: BigDecimal!
 
@@ -60,7 +60,7 @@ type Exchange @entity {
     weightedAvgPriceUSD: BigDecimal!        # weightAvgPriceUSD = ( $1 of ETH in ETH ) / weightedAvgPrice
 
     # Fields used to help derived relationship
-    factory: Uniswap! @derivedFrom(field: "exchanges")
+    factory: Uniswap
     tokenHolders: [UserExchangeData!]       # Relationship to show all token holders on the exchange
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -69,7 +69,7 @@ type User @entity {
     exchangeBalances: [UserExchangeData!]!  @derivedFrom(field: "user")
 }
 
-# trading and liquidity data around a user and their activity on a given exchange 
+# trading and liquidity data around a user and their activity on a given exchange
 type UserExchangeData @entity {
     id: ID!                         # ID is concatenation of token and user addr. i.e. 0xahiow4-0xkashkd34....
     userAddress: Bytes!
@@ -129,7 +129,7 @@ type AddLiquidityEvent implements TransactionEvent  @entity {
     transaction: Transaction! @derivedFrom(field: "addLiquidityEvents")
     ethAmount: BigDecimal!
     tokenAmount: BigDecimal!
-    uniTokensMinted: BigDecimal! 
+    uniTokensMinted: BigDecimal!
 }
 
 # Note - No fee to provide liqidity
@@ -138,7 +138,7 @@ type RemoveLiquidityEvent implements TransactionEvent @entity {
     transaction: Transaction! @derivedFrom(field: "removeLiquidityEvents")
     ethAmount: BigDecimal!
     tokenAmount: BigDecimal!
-    uniTokensBurned: BigDecimal! 
+    uniTokensBurned: BigDecimal!
 }
 
 type TokenPurchaseEvent implements TransactionEvent @entity {
@@ -199,7 +199,7 @@ type ExchangeDayData @entity {
     marginalEthRate: BigDecimal!            # tokenBalance / ethBalance
     ethVolume: BigDecimal!                  # Cumulative volume throughout the day
     tokenPriceUSD: BigDecimal!              # USD token price at last event within the day
-    totalEvents: BigInt!                    
+    totalEvents: BigInt!
 }
 
 # Data accumulated and condensed into day stats for all of Uniswap
@@ -240,6 +240,3 @@ type UniswapHistoricalData @entity {
 
     txCount: BigInt!
 }
-
-
-

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,7 +108,7 @@ type Transaction @entity {
     exchangeAddress: Bytes!
     addLiquidityEvents: [AddLiquidityEvent!] @derivedFrom(field: "transaction")
     removeLiquidityEvents: [RemoveLiquidityEvent!] @derivedFrom(field: "transaction")
-    tokenPurchaseEvents: [TokenPurchaseEvent!]
+    tokenPurchaseEvents: [TokenPurchaseEvent!] @derivedFrom(field: "transaction")
     ethPurchaseEvents: [EthPurchaseEvent!]
     block: Int!
     timestamp: Int!
@@ -143,7 +143,7 @@ type RemoveLiquidityEvent implements TransactionEvent @entity {
 
 type TokenPurchaseEvent implements TransactionEvent @entity {
     id: ID!                 # Incrementing ID, 1, 2, etc, as txhashes can contain multiple events
-    transaction: Transaction! @derivedFrom(field: "tokenPurchaseEvents")
+    transaction: Transaction!
     # Monetary Values. Positive or negative determined by the TradeType
     ethAmount: BigDecimal!
     tokenAmount: BigDecimal!

--- a/schema.graphql
+++ b/schema.graphql
@@ -109,7 +109,7 @@ type Transaction @entity {
     addLiquidityEvents: [AddLiquidityEvent!] @derivedFrom(field: "transaction")
     removeLiquidityEvents: [RemoveLiquidityEvent!] @derivedFrom(field: "transaction")
     tokenPurchaseEvents: [TokenPurchaseEvent!] @derivedFrom(field: "transaction")
-    ethPurchaseEvents: [EthPurchaseEvent!]
+    ethPurchaseEvents: [EthPurchaseEvent!] @derivedFrom(field: "transaction")
     block: Int!
     timestamp: Int!
     user: Bytes!
@@ -153,7 +153,7 @@ type TokenPurchaseEvent implements TransactionEvent @entity {
 
 type EthPurchaseEvent implements TransactionEvent @entity {
     id: ID!                 # Incrementing ID, 1, 2, etc, as txhashes can contain multiple events
-    transaction: Transaction! @derivedFrom(field: "ethPurchaseEvents")
+    transaction: Transaction!
     # Monetary Values. Positive or negative determined by the TradeType
     ethAmount: BigDecimal!
     tokenAmount: BigDecimal!

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,7 +106,7 @@ enum EventType {
 type Transaction @entity {
     id: ID!  # txn  hash concatenated with exchange - need this for token to token swaps
     exchangeAddress: Bytes!
-    addLiquidityEvents: [AddLiquidityEvent!]
+    addLiquidityEvents: [AddLiquidityEvent!] @derivedFrom(field: "transaction")
     removeLiquidityEvents: [RemoveLiquidityEvent!]
     tokenPurchaseEvents: [TokenPurchaseEvent!]
     ethPurchaseEvents: [EthPurchaseEvent!]
@@ -126,7 +126,7 @@ interface TransactionEvent {
 # Note - No fee to provide liqidity
 type AddLiquidityEvent implements TransactionEvent  @entity {
     id: ID!                 # Incrementing ID, 1, 2, etc, as txhashes can contain multiple events
-    transaction: Transaction! @derivedFrom(field: "addLiquidityEvents")
+    transaction: Transaction!
     ethAmount: BigDecimal!
     tokenAmount: BigDecimal!
     uniTokensMinted: BigDecimal!

--- a/src/mappings/exchange.ts
+++ b/src/mappings/exchange.ts
@@ -450,15 +450,6 @@ export function handleEthPurchase(event: EthPurchase): void {
     uniswapDayData.txCount = uniswap.txCount
     uniswapDayData.save()
 
-    /*** Create Trade Event ******/
-    const eventID = uniswap.totalTokenBuys.plus(uniswap.totalTokenSells)
-    const ethPurchaseEvent = new EthPurchaseEvent(eventID.toString().concat('-ep'))
-    ethPurchaseEvent.ethAmount = ethAmount
-    ethPurchaseEvent.tokenFee = fee
-    ethPurchaseEvent.ethFee = zeroBD()
-    ethPurchaseEvent.tokenAmount = tokenAmount
-    ethPurchaseEvent.save()
-
     /****** Update Transaction ******/
     const txId = event.transaction.hash
       .toHexString()
@@ -468,15 +459,22 @@ export function handleEthPurchase(event: EthPurchase): void {
     if (transaction == null) {
       transaction = new Transaction(txId)
     }
-    const ethPurchaseEvents = transaction.ethPurchaseEvents || []
-    ethPurchaseEvents.push(ethPurchaseEvent.id)
-    transaction.ethPurchaseEvents = ethPurchaseEvents
     transaction.exchangeAddress = event.address
     transaction.block = event.block.number.toI32()
     transaction.timestamp = event.block.timestamp.toI32()
     transaction.user = event.params.buyer
     transaction.fee = fee
     transaction.save()
+
+    /*** Create Trade Event ******/
+    const eventID = uniswap.totalTokenBuys.plus(uniswap.totalTokenSells)
+    const ethPurchaseEvent = new EthPurchaseEvent(eventID.toString().concat('-ep'))
+    ethPurchaseEvent.ethAmount = ethAmount
+    ethPurchaseEvent.tokenFee = fee
+    ethPurchaseEvent.ethFee = zeroBD()
+    ethPurchaseEvent.tokenAmount = tokenAmount
+    ethPurchaseEvent.transaction = txId
+    ethPurchaseEvent.save()
 
     /************************************
      * Handle the historical data below *

--- a/src/mappings/exchange.ts
+++ b/src/mappings/exchange.ts
@@ -227,15 +227,6 @@ export function handleTokenPurchase(event: TokenPurchase): void {
     uniswapDayData.txCount = uniswap.txCount
     uniswapDayData.save()
 
-    /******** CREATE TRADE EVENT  ********/
-    const eventID = uniswap.totalTokenBuys.plus(uniswap.totalTokenSells)
-    const tokenPurchaseEvent = new TokenPurchaseEvent(eventID.toString().concat('-tp'))
-    tokenPurchaseEvent.ethAmount = ethAmount
-    tokenPurchaseEvent.tokenAmount = tokenAmount
-    tokenPurchaseEvent.tokenFee = zeroBD()
-    tokenPurchaseEvent.ethFee = fee
-    tokenPurchaseEvent.save()
-
     /****** Update Transaction ******/
     const txId = event.transaction.hash
       .toHexString()
@@ -245,15 +236,22 @@ export function handleTokenPurchase(event: TokenPurchase): void {
     if (transaction == null) {
       transaction = new Transaction(txId)
     }
-    const tokenPurchaseEvents = transaction.tokenPurchaseEvents || []
-    tokenPurchaseEvents.push(tokenPurchaseEvent.id)
-    transaction.tokenPurchaseEvents = tokenPurchaseEvents
     transaction.exchangeAddress = event.address
     transaction.block = event.block.number.toI32()
     transaction.timestamp = event.block.timestamp.toI32()
     transaction.user = event.params.buyer
     transaction.fee = fee
     transaction.save()
+
+    /******** CREATE TRADE EVENT  ********/
+    const eventID = uniswap.totalTokenBuys.plus(uniswap.totalTokenSells)
+    const tokenPurchaseEvent = new TokenPurchaseEvent(eventID.toString().concat('-tp'))
+    tokenPurchaseEvent.ethAmount = ethAmount
+    tokenPurchaseEvent.tokenAmount = tokenAmount
+    tokenPurchaseEvent.tokenFee = zeroBD()
+    tokenPurchaseEvent.ethFee = fee
+    tokenPurchaseEvent.transaction = txId
+    tokenPurchaseEvent.save()
 
     /************************************
      * Handle the historical data below *

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -57,12 +57,7 @@ function hardcodeExchange(exchangeAddress: string, tokenAddress: Address, timest
 
   // only save for tokens with non null decimals
   if (exchange.tokenDecimals !== null) {
-    // add the exchange for the derived relationship
-    const uniswap = Uniswap.load('1')
-    const currentExchanges = uniswap.exchanges
-    currentExchanges.push(exchange.id)
-    uniswap.exchanges = currentExchanges
-    uniswap.save()
+    exchange.factory = '1'
     exchange.save()
   }
 }
@@ -74,7 +69,6 @@ export function handleNewExchange(event: NewExchange): void {
   if (factory == null) {
     factory = new Uniswap('1')
     factory.exchangeCount = 0
-    factory.exchanges = []
     factory.totalVolumeInEth = zeroBD()
     factory.totalLiquidityInEth = zeroBD()
     factory.totalVolumeUSD = zeroBD()


### PR DESCRIPTION
This pull request reverse how 1:n associations are stored in Uniswap: rather than storing them as an array on the 'n' side, they are now stored as a scalar attribute on the '1' side. Doing it this way makes things much easier for the database when executing queries.

One downside is that changing which side is stored and which side is derived changes what filters are available - if that conflicts with how Uniswap needs to be queried, feel free to ignore any of this.

I did sync with this version of Uniswap on a test system successfully, but I don't know the ins and outs of the subgraph enough to be able to tell whether I broke some other functionality.